### PR TITLE
warn (don't die) on `uname` errors

### DIFF
--- a/lib/Dist/Zilla/Plugin/MetaData/BuiltWith.pm
+++ b/lib/Dist/Zilla/Plugin/MetaData/BuiltWith.pm
@@ -239,7 +239,7 @@ sub _uname {
   }
   ## no critic ( ProhibitPunctuationVars )
 
-  $self->_my_log_fatal( 'Error calling uname:', $@, $! );
+  $self->log(q{WARNING: `uname` invocation failed, omit from metadata});
 
   return ();
 


### PR DESCRIPTION
- change fatal exception to warning and return of empty results for _uname()

.# Discussion

Local versions of `uname` may not support all options, which will cause errors upon
invocation. Previously, this killed the build. Now, the error output of `uname` will
be printed (by `uname`), followed by a warning entered into the build log. But the
build will continue. This allows builds on systems with oulder `uname` versions.

This was unnecessarily tripping up builds on my machine with an older version of `uname`. I didn't want to make a wholesale change, but it might be better to Capture::Tiny all the output and log the `uname` error output. If you're interested, I can refactor for that outcome.
